### PR TITLE
Accept none in the response results

### DIFF
--- a/ankr/providers.py
+++ b/ankr/providers.py
@@ -68,8 +68,11 @@ class MultichainHTTPProvider(HTTPProvider):
                 return
             limit -= len(items)
 
-        yield from items
-
+        if items is None:
+            yield from []
+        else:
+            yield from items
+        
         if reply.next_page_token:
             request.page_token = reply.next_page_token
             yield from self.call_method_paginated(

--- a/ankr/types.py
+++ b/ankr/types.py
@@ -175,9 +175,9 @@ class GetTokenHoldersReply(RPCReplyPaginated):
     blockchain: BlockchainName
     contract_address: str
     token_decimals: int
-    holders: List[HolderBalance]
+    holders: Union[None, List[HolderBalance]]
     holders_count: int
-    next_page_token: str
+    next_page_token: Optional[str] = None
 
 
 class GetTokenHoldersCountRequest(RPCRequestPaginated):


### PR DESCRIPTION
The method was failing with validation error that 'none' is not expected.

The error comes when the last page is requested, and it returns "none" as the holders array.
